### PR TITLE
satisfy rails4 deprecation warning on magic find_or_create_by method

### DIFF
--- a/lib/protokoll/counter.rb
+++ b/lib/protokoll/counter.rb
@@ -3,7 +3,7 @@ require 'active_record'
 module Protokoll
   class Counter
     def self.next(object, options)
-      element = Models::CustomAutoIncrement.find_or_create_by_model_name(object.class.to_s.underscore)
+      element = Models::CustomAutoIncrement.find_or_create_by(model_name: object.class.to_s.underscore)
 
       element.counter = options[:start] if outdated?(element, options) || element.counter == 0
       element.counter += 1


### PR DESCRIPTION
I recommend creating a 'rails4' branch and pulling to that branch. That way people can use it selectively via 

```
gem 'protokoll', git: 'git://github.com/celsodantas/protokoll.git', branch: 'rails4'
```
