### PR TITLE
Fixed LocalJumpError: unexpected return

### DIFF
--- a/lib/protokoll/protokoll.rb
+++ b/lib/protokoll/protokoll.rb
@@ -26,8 +26,8 @@ module Protokoll
       # Signing before_create
       before_create do |record|
         unless record[column].present?
-	        record[column] = Counter.next(self, options)
-	      end
+          record[column] = Counter.next(self, options)
+        end
       end
     end
   end


### PR DESCRIPTION
When using reserve_number! on an object and then try to save it, it gives LocalJumpError: unexpected return error.

I think the issue is related to this one on rails repo:
rails/rails#12981
and this pull request on rails repo too:
rails/rails#13271
