### PR TITLE
Allow rails > 4 as a valid dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 rvm:
-  - 1.9.3
+  - 2.2.4
+  - 2.3.0
 
 script: bundle exec rake -f test/dummy/Rakefile db:migrate db:test:prepare; bundle exec rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,3 @@ gemspec
 # your gem to rubygems.org.
 
 gem 'timecop'
-gem 'debugger'

--- a/protokoll.gemspec
+++ b/protokoll.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency("rails", "~> 4.0")
+  s.add_dependency("rails", ">= 4.0")
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
I'm working on a project that uses protokoll, and thought I'd try out the new Rails 5.0.0.beta1. But bundler complained, because protokoll depends on rails ~> 4.0 (i.e., up to rails 4.99999..., but no further).

I've changed the dependency in the gemspec to >= 4.0, and the tests still pass running against rails 5.0.0.beta1. You might want to run some more tests using a Rails 5 app though, perhaps.