### PR TITLE
Fix sqlite3 dependency issue in development

### DIFF
--- a/protokoll.gemspec
+++ b/protokoll.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("rails", "~> 4.0", "> 4.0")
 
-  s.add_development_dependency "sqlite3", '~> 0'
+  s.add_development_dependency "sqlite3", '~> 1'
 end


### PR DESCRIPTION
Just for avoid the next issue:
_specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)_