### PR TITLE
Relax rails dependency to allow >= 4

### DIFF
--- a/protokoll.gemspec
+++ b/protokoll.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency("rails", "~> 4.0", "> 4.0")
+  s.add_dependency("rails", ">= 4.0")
 
   s.add_development_dependency "sqlite3", '~> 1'
 end


### PR DESCRIPTION
I think you unintentionally restricted the gem to rails 4 only (not 5) again here: https://github.com/celsodantas/protokoll/commit/d06a33c3a72cdfe3addd256452bb9eed19545560