### PR TITLE
Add support for ActiveType 'Presenters'

### DIFF
--- a/lib/protokoll/counter.rb
+++ b/lib/protokoll/counter.rb
@@ -19,7 +19,7 @@ module Protokoll
     private
 
     def self.build_attrs(object, options)
-      attrs = {counter_model_name: object.class.to_s.underscore}
+      attrs = {counter_model_name: object.model_name.name.underscore}
       return attrs unless options[:scope_by]
 
       scope_by =  options[:scope_by].respond_to?(:call) ?


### PR DESCRIPTION
Protokoll does not work correctly when using ActiveType 'Presenters' (https://github.com/makandra/active_type - allow multiple subclasses to represent the same model in different contexts).

This can be solved be using #model_name.name rather #class.to_s, which is usually equivalent but customizable for instances like this (api.rubyonrails.org/classes/ActiveModel/Naming.html)